### PR TITLE
chore(ci): publish to github package registry

### DIFF
--- a/.github/workflows/publish_gpr.yml
+++ b/.github/workflows/publish_gpr.yml
@@ -2,12 +2,15 @@ name: Publish
 
 on:
     release:
-        types: [created]
+        types: [published]
     workflow_dispatch:
 
 jobs:
-    build:
+    publish-gpr:
         runs-on: ubuntu-latest
+        permissions:
+            packages: write
+            contents: read
         steps:
             - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
               with:
@@ -50,26 +53,6 @@ jobs:
                 TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
               run: pnpm typecheck
 
-    publish-gpr:
-        needs: build
-        runs-on: ubuntu-latest
-        permissions:
-            packages: write
-            contents: read
-        steps:
-            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-              with:
-                fetch-depth: 0
-
-            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-
-            - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-              with:
-                node-version: 22.x
-                registry-url: 'https://npm.pkg.github.com'
-                cache: pnpm
-
-            - run: pnpm install --frozen-lockfile
-            - run: pnpm -r publish --access public --no-git-checks --registry https://npm.pkg.github.com/
+            - run: pnpm -r publish --no-git-checks --registry https://npm.pkg.github.com/
               env:
                 NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_gpr.yml
+++ b/.github/workflows/publish_gpr.yml
@@ -1,0 +1,75 @@
+name: Publish
+
+on:
+    release:
+        types: [created]
+    workflow_dispatch:
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+              with:
+                fetch-depth: 0
+
+            - name: Cache turbo build setup
+              uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+              with:
+                path: .turbo
+                key: ${{ runner.os }}-turbo-${{ github.sha }}
+                restore-keys: |
+                  ${{ runner.os }}-turbo-
+
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+            - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+              with:
+                node-version: 22.x
+                registry-url: 'https://registry.npmjs.org'
+                cache: pnpm
+            
+            - name: Install
+              run: pnpm install
+            
+            - name: Build
+              env:
+                TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+                TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+              run: pnpm build
+
+            - name: Test
+              env:
+                TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+                TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+              run: pnpm test
+
+            - name: Typecheck
+              env:
+                TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+                TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
+              run: pnpm typecheck
+
+    publish-gpr:
+        needs: build
+        runs-on: ubuntu-latest
+        permissions:
+            packages: write
+            contents: read
+        steps:
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+              with:
+                fetch-depth: 0
+
+            - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+            - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+              with:
+                node-version: 22.x
+                registry-url: 'https://npm.pkg.github.com'
+                cache: pnpm
+
+            - run: pnpm install --frozen-lockfile
+            - run: pnpm -r publish --access public --no-git-checks --registry https://npm.pkg.github.com/
+              env:
+                NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated release pipeline that builds, tests, typechecks, and publishes packages to GitHub Packages when a release is created or triggered manually.
  * Improved CI reliability and speed with standardized Node/pnpm setup, caching, and explicit environment handling.
  * Publishes all packages using repository authentication to streamline releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->