### PR TITLE
docs(fix): og image url

### DIFF
--- a/apps/www/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/www/src/app/docs/[[...slug]]/page.tsx
@@ -15,6 +15,7 @@ import path from "node:path";
 import { LLMCopyButton, ViewOptions } from "@/components/page-actions";
 import { DocsFooter } from "./_components/footer";
 import { owner, repo } from "@/lib/github";
+import type { Metadata } from "next";
 
 const removeExt = (fullPath: string) => {
 	const parsed = path.parse(fullPath);
@@ -93,7 +94,7 @@ export async function generateMetadata({
 	const { slug } = await params;
 	const page = source.getPage(slug);
 	if (page == null) notFound();
-	const url = new URL(`${baseUrl}api/og`);
+	const url = new URL(`https://better-auth-extended.jsolano.de/api/og`);
 	const { title, description, packageName } = page.data;
 	const pageSlug = page.path;
 	url.searchParams.set("type", "Documentation");
@@ -114,7 +115,7 @@ export async function generateMetadata({
 			title,
 			description,
 			type: "website",
-			url: `${baseUrl}docs/${removeExt(pageSlug)}`,
+			url: `https://better-auth-extended.jsolano.de/docs/${removeExt(pageSlug)}`,
 			images: [
 				{
 					url: url.toString(),
@@ -130,5 +131,5 @@ export async function generateMetadata({
 			description,
 			images: [url.toString()],
 		},
-	};
+	} satisfies Metadata;
 }

--- a/apps/www/src/lib/metadata.ts
+++ b/apps/www/src/lib/metadata.ts
@@ -18,8 +18,8 @@ export const createMetadata = (override: Metadata): Metadata => {
 		openGraph: {
 			title: override.title ?? undefined,
 			description: override.description ?? undefined,
-			url: baseUrl,
-			images: `${baseUrl}og.png`,
+			url: "https://better-auth-extended.jsolano.de",
+			images: "https://better-auth-extended.jsolano.de/og.png",
 			siteName: "better-auth-extended",
 			...override.openGraph,
 		},
@@ -28,7 +28,7 @@ export const createMetadata = (override: Metadata): Metadata => {
 			creator: "@j_slno",
 			title: override.title ?? undefined,
 			description: override.description ?? undefined,
-			images: `${baseUrl}og.png`,
+			images: "https://better-auth-extended.jsolano.de/og.png",
 			...override.twitter,
 		},
 	};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Social sharing metadata now uses absolute URLs for OpenGraph and Twitter images, ensuring consistent link previews and preventing broken or missing share images across environments.
  - Link cards for docs and API previews now reliably display the intended og.png.

- Chores
  - Updated metadata handling while preserving existing override behavior; no content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->